### PR TITLE
Ref cache sqlite

### DIFF
--- a/project.nix
+++ b/project.nix
@@ -35,6 +35,7 @@ let
     "servant-lucid"
     "servant-server"
     "servant"
+    "sqlite-simple"
     "text"
     "transformers"
     "unordered-containers"
@@ -166,8 +167,8 @@ let
       ghc-options:         -O3 ${joinSpaces ghc-build-options}
 
     ${if false then "" else ''
-    executable nar-parse
-      main-is:             Nix/PrintNar.hs
+    executable ref-cache
+      main-is:             Nix/ReferenceCache.hs
       build-depends:       ${joinCommas dependencies}
       hs-source-dirs:      src
       default-language:    Haskell2010

--- a/src/Nix/Bin.hs
+++ b/src/Nix/Bin.hs
@@ -16,7 +16,8 @@ import Nix.StorePath (StorePath, FullStorePath, NixStoreDir,
                       ioParseFullStorePath)
 
 -- | Path to the directory containing nix binaries.
-newtype NixBinDir = NixBinDir FilePath deriving (Show, Eq, IsString)
+newtype NixBinDir = NixBinDir {unpackNixBinDir::FilePath}
+  deriving (Show, Eq, IsString)
 
 -- | Get the nix binary directory path, e.g. where `nix-store` lives.
 getNixBinDir :: IO NixBinDir

--- a/src/Nix/Cache/Client.hs
+++ b/src/Nix/Cache/Client.hs
@@ -1,9 +1,7 @@
 module Nix.Cache.Client where
 
-import ClassyPrelude (writeFile)
 import Control.Concurrent.Async.Lifted (wait)
 import Control.Monad.State.Strict (execStateT, modify)
-import Database.SQLite.Simple (Connection)
 import GHC.Conc (getNumProcessors)
 import Network.HTTP.Client (Manager, Request(..), ManagerSettings(..))
 import Network.HTTP.Client (newManager, defaultManagerSettings)
@@ -13,25 +11,21 @@ import Servant.Client (BaseUrl(..), ClientM, ClientEnv(ClientEnv), Scheme(..))
 import Servant.Client (runClientM, client, )
 import Servant.Common.BaseUrl (parseBaseUrl)
 import System.Exit (ExitCode(ExitSuccess, ExitFailure))
-import System.Directory (createDirectoryIfMissing, renameDirectory)
-import System.Directory (doesDirectoryExist)
 import System.Environment (lookupEnv)
 import System.Process.Text (readProcessWithExitCode)
-import System.Process (readCreateProcess, shell)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.HashMap.Strict as H
 import qualified Data.HashSet as HS
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Vector as V
-import qualified Data.HashSet as HS
 
 import Nix.Cache.Common
 import Nix.Cache.API
-import Nix.StorePath (NixStoreDir, StorePath, PathSet, PathTree)
-import Nix.StorePath (parseFullStorePath, ioParseStorePath)
+import Nix.StorePath (NixStoreDir, StorePath, PathSet)
 import Nix.StorePath (ioParseFullStorePath, spToFull)
-import Nix.StorePath (getNixStoreDir, spToPath, abbrevSP)
+import Nix.StorePath (getNixStoreDir, abbrevSP)
+import Nix.ReferenceCache
 import Nix.Cache.Types
 import Nix.Nar
 import Nix.NarInfo
@@ -85,77 +79,6 @@ nixCacheUrlFromEnv = do
   parseBaseUrl base
 
 -------------------------------------------------------------------------------
--- * Local filesystem cache for path references
-
--- TODO: use sqlite
--------------------------------------------------------------------------------
-
--- | Write a path tree to the cache.
--- Iterates through keys of the path tree, for each one creates a
--- directory for the base path of the store path, and touches files
--- corresponding to paths of its dependencies.
--- So for example, if /nix/store/xyz-foo depends on /nix/store/{a,b,c},
--- then we will create
---   cacheLocation/xyz-foo/a
---   cacheLocation/xyz-foo/b
---   cacheLocation/xyz-foo/c
-writeCache :: NixClient ()
-writeCache = do
-  error "TURDBURGLERS"
-  cacheLocation <- nccCacheLocation <$> ncoConfig <$> ask
-  mv <- ncoState <$> ask
-  tree <- ncsPathTree <$> readMVar mv
-  liftIO $ createDirectoryIfMissing True cacheLocation
-  forM_ (H.toList tree) $ \(path, refs) -> do
-    writeCacheFor path (HS.toList refs)
-
--- Write the on-disk cache entry for a single path.
-writeCacheFor :: StorePath -> [StorePath] -> NixClient ()
-writeCacheFor path refs = do
-  cacheLocation <- nccCacheLocation <$> ncoConfig <$> ask
-  let pathDir = cacheLocation </> spToPath path
-  liftIO (doesDirectoryExist pathDir) >>= \case
-    True -> pure ()
-    False -> liftIO $ do
-      -- Build the cache in a temporary directory, and then move it
-      -- to the actual location. This prevents the creation of a
-      -- partial directory in the case of a crash.
-      tempDir <- T.unpack . T.strip . T.pack <$>
-        readCreateProcess (shell $ "mktemp -d " <> pathDir <> "XXXX") ""
-      forM_ refs $ \ref -> do
-        writeFile (tempDir </> spToPath ref) ""
-      renameDirectory tempDir pathDir
-      -- Make the directory read-only.
-      readCreateProcess (shell $ "chmod 0555 " <> pathDir) ""
-      pure ()
-
--- | Read the references of a single path from the cache, if they exist.
-getReferencesFromCache :: StorePath -> NixClient (Maybe PathSet)
-getReferencesFromCache spath = do
-  ncDebug $ "Querying cache for references of " <> abbrevSP spath
-  cacheLocation <- nccCacheLocation <$> ncoConfig <$> ask
-  liftIO $ do
-    doesDirectoryExist (cacheLocation </> spToPath spath) >>= \case
-      True -> Just <$> do
-        refStrs <- map pack <$> listDirectory cacheLocation
-        HS.fromList <$> mapM ioParseStorePath refStrs
-      False -> pure Nothing
-
--- | Load a cache from disk into memory.
-loadCache :: FilePath -> IO PathTree
-loadCache cacheLocation = doesDirectoryExist cacheLocation >>= \case
-  False -> pure mempty
-  True -> do
-    paths <- listDirectory cacheLocation
-    map H.fromList $ forM paths $ \path -> do
-      bpath <- ioParseStorePath $ pack path
-      deps <- do
-        depfiles <- listDirectory (cacheLocation </> path)
-        HS.fromList <$> mapM (ioParseStorePath . pack) depfiles
-      pure (bpath, deps)
-
-
--------------------------------------------------------------------------------
 -- * Nix client monad
 -------------------------------------------------------------------------------
 
@@ -165,8 +88,6 @@ data NixClientConfig = NixClientConfig {
   -- ^ Location of the nix store.
   nccBinDir :: NixBinDir,
   -- ^ Location of nix binaries.
-  nccCacheLocation :: FilePath,
-  -- ^ Location of the nix client path cache.
   nccCacheUrl :: BaseUrl,
   -- ^ Base url of the nix binary cache.
   nccCacheAuth :: Maybe NixCacheAuth,
@@ -179,9 +100,8 @@ data NixClientConfig = NixClientConfig {
 
 -- | State for the nix client monad.
 data NixClientState = NixClientState {
-  ncsPathTree :: PathTree,
   -- ^ Computed store path dependency tree.
-  ncsSentPaths :: HashMap StorePath (Async ())
+  ncsSentPaths :: !(HashMap StorePath (Async ()))
   -- ^ Mapping of store paths to asynchronous actions which send those paths.
   } deriving (Generic)
 
@@ -193,7 +113,7 @@ data NixClientObj = NixClientObj {
   -- ^ Mutable state of the client.
   ncoManager :: Manager,
   -- ^ HTTP connection manager client uses to connect.
-  -- ncoPathReferenceCache :: NixPathReferenceCache,
+  ncoPathReferenceCache :: NixPathReferenceCache,
   -- ^ Database connection for the local cache. Syncronized in MVar to
   -- allow lastrowid to be deterministic
   ncoLogMutex :: MVar (),
@@ -209,11 +129,6 @@ loadClientConfig = do
   nccStoreDir <- getNixStoreDir
   nccCacheUrl <- nixCacheUrlFromEnv
   nccCacheAuth <- authFromEnv
-  nccCacheLocation <- lookupEnv "CLIENT_SQLITE_CACHE" >>= \case
-    Just location -> pure location
-    Nothing -> lookupEnv "HOME" >>= \case
-      Nothing -> error "HOME variable isn't set"
-      Just home -> pure (home </> ".nix-client-cache")
   nccMaxWorkers <- (>>= readMay) <$> lookupEnv "MAX_WORKERS" >>= \case
     Just n | n > 0 -> return n
     _ -> getNumProcessors
@@ -229,11 +144,11 @@ runNixClient action = do
   cfg <- loadClientConfig
   semaphore <- newQSem (nccMaxWorkers cfg)
   manager <- mkManager cfg
-  let state = NixClientState mempty mempty
+  let state = NixClientState mempty
   stateMVar <- newMVar state
   logMVar <- newMVar ()
-  -- TODO make this configurable
-  let obj = NixClientObj cfg stateMVar manager logMVar semaphore
+  cache <- newPathReferenceCache
+  let obj = NixClientObj cfg stateMVar manager cache logMVar semaphore
   -- Perform the action and then update the cache.
   result <- runReaderT (action) obj
   pure result
@@ -314,37 +229,11 @@ clientRequest req = do
 -- * Nix client actions
 -------------------------------------------------------------------------------
 
--- | Get the references of an object by asking the nix-store. This
--- information is cached by the caller of this function.
-getReferencesFromNix :: StorePath -> NixClient PathSet
-getReferencesFromNix spath = do
-  ncDebug $ "Querying nix-store for references of " <> abbrevSP spath
-  storeDir <- nccStoreDir <$> ncoConfig <$> ask
-  let cmd = "nix-store --query --references " <> spToFull storeDir spath
-  result <- liftIO $ pack <$> readCreateProcess (shell $ unpack cmd) ""
-  map HS.fromList $ do
-    forM (T.words result) $ \line -> case parseFullStorePath line of
-      Left err -> error err
-      Right (_, sp) -> pure sp
-
 -- | Get references of a path, reading from and writing to a cache.
 getReferences :: StorePath -> NixClient PathSet
 getReferences spath = do
-  mv <- asks ncoState
-  modifyMVar mv $ \s -> do
-    -- Adds some new references to the path tree.
-    let addRefs refs = s {ncsPathTree = H.insert spath refs $ ncsPathTree s}
-    case lookup spath $ ncsPathTree s of
-      Just refs -> pure (s, refs :: PathSet)
-      -- Next check the on-disk cache.
-      Nothing -> getReferencesFromCache spath >>= \case
-        Just refs -> pure (addRefs refs, refs :: PathSet)
-        -- If it's still not there, then ask nix-store for the references.
-        Nothing -> do
-          refs' <- getReferencesFromNix spath
-          -- Filter out self-referential paths.
-          let refs = HS.filter (/= spath) refs'
-          pure (addRefs refs, refs :: PathSet)
+  cache <- ncoPathReferenceCache <$> ask
+  liftIO $ getPathReferences cache spath
 
 -- | Get the full runtime path dependency closure of a store path.
 getClosure :: StorePath -> NixClient [StorePath]

--- a/src/Nix/FileHash.hs
+++ b/src/Nix/FileHash.hs
@@ -2,6 +2,7 @@
 module Nix.FileHash where
 
 import ClassyPrelude
+import Database.SQLite.Simple.FromField (FromField(fromField))
 import qualified Data.Text as T
 
 -- | A representation of a hash, which expresses the type of
@@ -15,6 +16,12 @@ data FileHash
   | Md5Hash Text -- ^ Hash computed with sha256.
   | RecursiveHash FileHash -- ^ Hash should be computed over a directory.
   deriving (Show, Eq, Generic)
+
+instance FromField FileHash where
+  fromField f = do
+    fileHashFromText <$> fromField f >>= \case
+      Right hash -> pure hash
+      Left err -> fail err
 
 -- | Translate a file hash to text.
 fileHashToText :: FileHash -> Text

--- a/src/Nix/ReferenceCache.hs
+++ b/src/Nix/ReferenceCache.hs
@@ -1,0 +1,260 @@
+-- | Cache store paths and their references
+module Main where
+
+import Database.SQLite.Simple (FromRow(..), ToRow(..), Connection, Query)
+import Database.SQLite.Simple (Only(..), field, lastInsertRowId)
+import Database.SQLite.Simple (open, execute_, execute, query, query_)
+import qualified Data.HashMap.Strict as H
+import qualified Data.HashSet as HS
+import qualified Data.Text as T
+import System.Process.Text (readProcessWithExitCode)
+import System.Exit (ExitCode(..))
+
+import Nix.Cache.Common
+import Nix.Cache.Client hiding (writeCache, writeCacheFor)
+import Nix.Bin
+import Nix.StorePath -- (StorePath(..))
+import Nix.NarInfo ()
+
+data TestField = TestField Int Text deriving (Show)
+
+instance FromRow TestField where
+  fromRow = TestField <$> field <*> field
+
+instance ToRow TestField where
+  toRow (TestField id_ str) = toRow (id_, str)
+
+-- | Path reference cache, backed by sqlite
+data NixPathReferenceCache = NixPathReferenceCache {
+  nprcStoreDir :: NixStoreDir,
+  nprcLocalNixDbConnection :: Maybe Connection,
+  -- ^ What's the path to the nix DB?
+  nprcBinDir :: NixBinDir,
+  nprcCacheLocation :: FilePath,
+  -- ^ Where does the cache live on disk?
+  nprcConnection :: MVar Connection,
+  -- ^ Database connection for the local cache. Syncronized in MVar to
+  -- allow lastrowid to be deterministic.
+  nprcPathIdCache :: MVar (HashMap StorePath Int64),
+  -- ^ Map store paths to their database row ID, so that we don't have to
+  -- look them up all the time.
+  nprcPathTree :: MVar PathTree
+  -- ^ Computed store path dependency tree.
+  }
+
+-- | Attempt to connect to the local SQLite nix database. If the
+-- connection fails, or it doesn't have a ValidPaths table, return Nothing.
+attemptLocalNixConnection :: FilePath -> IO (Maybe Connection)
+attemptLocalNixConnection dbpath = do
+  conn <- open dbpath
+  let test = query_ conn "select count(*) from ValidPaths" :: IO [Only Int]
+  (Just conn <$ test) `catch` \(err::SomeException) -> do
+    putStrLn $ "Can't use local nix SQLite database: " <> tshow err
+    pure Nothing
+
+newPathReferenceCache :: FilePath -> IO NixPathReferenceCache
+newPathReferenceCache nprcCacheLocation = do
+  nprcLocalNixDbConnection <- attemptLocalNixConnection "/nix/var/nix/db/db.sqlite"
+  nprcStoreDir <- getNixStoreDir
+  nprcBinDir <- getNixBinDir
+  nprcConnection <- newMVar =<< open nprcCacheLocation
+  nprcPathIdCache <- newMVar mempty
+  nprcPathTree <- newMVar mempty
+  pure NixPathReferenceCache {..}
+
+-- | Get the references of an object by asking the nix-store. This
+-- information is cached by the caller of this function.
+getRefsFromNixDB :: NixPathReferenceCache -> StorePath -> IO PathSet
+getRefsFromNixDB cache spath = case nprcLocalNixDbConnection cache of
+  -- We can't access the DB directly. Use the CLI.
+  Nothing -> getRefsFromNixCommand cache spath
+  -- Pull the references directly out of the database.
+  Just conn -> do
+    -- Ensure it's in the nix DB by getting its ID
+    nixPathId <- do
+      let qry = "select id from ValidPaths where path = ?"
+      query conn qry (Only $ spToText spath) >>= \case
+        [Only pid] -> pure (pid :: Int64)
+        _ -> error $ "Path " <> show spath <> " not stored in the nix DB"
+
+    refs <- query conn getPathsQuery (Only nixPathId)
+    map HS.fromList $ map snd <$> mapM ioParseFullStorePath (map fromOnly refs)
+
+getRefsFromNixCommand :: NixPathReferenceCache -> StorePath -> IO PathSet
+getRefsFromNixCommand cache spath = do
+  let nixStoreCmd = unpackNixBinDir (nprcBinDir cache) </> "nix-store"
+      storeDir = nprcStoreDir cache
+  let args = ["--query", "--references", spToFull storeDir spath]
+  readProcessWithExitCode nixStoreCmd args "" >>= \case
+    (ExitSuccess, stdout, _) -> map HS.fromList $ do
+      map snd <$> mapM ioParseFullStorePath (splitWS stdout)
+    (ExitFailure code, _, stderr) -> error msg
+      where cmd = nixStoreCmd <> " " <> intercalate " " args
+            msg' = cmd <> " failed with " <> show code
+            msg = msg' <> unpack (if T.strip stderr == "" then ""
+                                  else "\nSTDERR:\n" <> stderr)
+
+-- writeCacheFor :: Connection -> StorePath -> [StorePath] -> NixClient ()
+-- writeCacheFor conn path refs = do
+
+
+-- writeCache :: NixClient ()
+--   cacheLocation <- nccCacheLocation <$> ncoConfig <$> ask
+--   conn <- liftIO $ open "test.db"
+--   mv <- ncoState <$> ask
+--   tree <- ncsPathTree <$> readMVar mv
+--   forM_ (H.toList tree) $ \(path, refs) -> do
+--     writeCacheFor path refs
+
+-- | Query which will return all of the references of a path.
+getPathsQuery :: Query
+getPathsQuery = fromString $ concat [
+  "select path from ValidPaths inner join (",
+  "select reference from ValidPaths inner join Refs on id = referrer where id = ?",
+  ") on id = reference"
+  ]
+
+getPathReferences :: NixPathReferenceCache -> StorePath -> IO PathSet
+getPathReferences cache path = getPathReferencesFromCache cache path >>= \case
+  Just refs -> do
+    putStrLn $ tshow path <> " is in the cache"
+    pure refs
+  Nothing -> do
+    putStrLn $ tshow path <> " not in cache, querying nix"
+    refs <- getRefsFromNixDB cache path
+    addPath cache path
+    storePathReferences cache path refs
+    pure refs
+
+getpaths :: Int -> IO [StorePath]
+getpaths n = do
+  NixStoreDir d <- getNixStoreDir
+  items <- take n <$> listDirectory d
+  forM items $ \item -> do
+    let Right sp = parseStorePath $ pack item
+    pure sp
+
+-- | Get a store path's references from the cache. Return Nothing if
+-- the path isn't recorded in the cache yet. Caches in memory.
+getPathReferencesFromCache
+  :: NixPathReferenceCache -> StorePath -> IO (Maybe PathSet)
+getPathReferencesFromCache cache path = do
+  modifyMVar (nprcPathTree cache) $ \tree -> do
+    case H.lookup path tree of
+      Just refs -> pure (tree, Just refs)
+      Nothing -> getPathId cache path >>= \case
+        Nothing -> do
+          putStrLn $ tshow path <> " not recorded"
+          pure (tree, Nothing)
+        Just pathId -> do
+          conn <- readMVar (nprcConnection cache)
+          let qry = "select refs from Paths where id = ?"
+          query conn qry (Only pathId) >>= \case
+            -- If references have been recorded, parse and return them
+            [Only (Just refs)] -> do
+              let refTexts = T.words refs
+              refs <- map HS.fromList $ forM refTexts $ \txt -> do
+                case parseStorePath txt of
+                  Right path -> pure path
+                  Left err -> error $ "When parsing references of path "
+                                   <> spToPath path <> ": " <> err
+              pure (H.insert path refs tree, Just refs)
+            _ -> do
+              putStrLn $ tshow path <> " references not recorded"
+              pure (tree, Nothing)
+
+-- | Get a store path's ID. Caches in memory.
+getPathId
+  :: NixPathReferenceCache -> StorePath -> IO (Maybe Int64)
+getPathId cache path = do
+  modifyMVar (nprcPathIdCache cache) $ \pathIdCache -> do
+    case H.lookup path pathIdCache of
+      Just pathId -> pure (pathIdCache, Just pathId)
+      Nothing -> do
+        let row = (Only $ spToText path)
+        withMVar (nprcConnection cache) $ \conn -> do
+          query conn "select id from Paths where path = ?" row >>= \case
+            [Only pathId'] -> do
+              pure (H.insert path pathId' pathIdCache, Just pathId')
+            _ -> do
+              pure (pathIdCache, Nothing)
+
+-- | Store the references of a path. Caches in memory and in the DB.
+storePathReferences
+  :: NixPathReferenceCache -> StorePath -> PathSet -> IO ()
+storePathReferences cache path refs = getPathId cache path >>= \case
+  Nothing -> error "Can't add references, path hasn't been stored"
+  Just pathId -> do
+    modifyMVar_ (nprcPathTree cache) $ \tree -> do
+      case H.lookup path tree of
+        Just refs' | refs == refs' -> pure tree
+        Just _ -> error $ "Inconsistent reference lists for path " <> show path
+        Nothing -> do
+          -- First insert them into the database, then add to the cache
+          withMVar (nprcConnection cache) $ \conn -> do
+            let refsText = intercalate " " $ map spToText $ HS.toList refs
+                qry = "update Paths set refs = ? where id = ?"
+            execute conn qry (refsText, pathId)
+            pure $ H.insert path refs tree
+
+
+-- | Add a store path (if it's not there yet) and get its ID. There are
+-- basically three cases here:
+--
+-- 1. In the in-memory cache: just return it.
+-- 2. In the database: add the ID to the in-memory cache, return it.
+-- 3. Not in the database: add it to the database, add new ID to the
+--    in-memory cache, and return it.
+addPath :: NixPathReferenceCache -> StorePath -> IO Int64
+addPath cache path = do
+  modifyMVar (nprcPathIdCache cache) $ \pathIdCache -> do
+    case H.lookup path pathIdCache of
+      Just pathId -> pure (pathIdCache, pathId)
+      Nothing -> do
+        let row = (Only $ spToText path)
+        pathId <- withMVar (nprcConnection cache) $ \conn -> do
+          query conn "select id from Paths where path = ?" row >>= \case
+            [Only pathId'] -> pure pathId'
+            _ -> do
+              let row = Only (spToText path)
+              execute conn "insert into Paths (path) values (?)" row
+              lastInsertRowId conn
+        pure (H.insert path pathId pathIdCache, pathId)
+
+
+-- | Create the tables in the path cache
+initializePathCache :: NixPathReferenceCache -> IO ()
+initializePathCache nprc = do
+  withMVar (nprcConnection nprc) $ \conn -> do
+    execute_ conn $ fromString $
+      "create table if not exists Paths " <>
+      "(id integer primary key, path text unique not null, refs text)"
+    execute_ conn
+      "create table if not exists Refs (referrer integer, reference integer)"
+
+getCache :: IO NixPathReferenceCache
+getCache = do
+  newPathReferenceCache =<< map nccCacheLocation loadClientConfig
+
+getConn :: IO Connection
+getConn = do
+  cache <- getCache
+  readMVar $ nprcConnection cache
+
+main :: IO ()
+main = do
+  cfg <- loadClientConfig
+  cache <- newPathReferenceCache (nccCacheLocation cfg)
+  initializePathCache cache
+  {-
+  conn <- open "test.db"
+  execute_ conn "CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, str TEXT)"
+  execute conn "INSERT INTO test (str) VALUES (?)" (Only ("test string 2" :: String))
+  execute conn "INSERT INTO test (id, str) VALUES (?,?)" (TestField 13 "test string 3")
+  rowId <- lastInsertRowId conn
+  executeNamed conn "UPDATE test SET str = :str WHERE id = :id" [":str" := ("updated str" :: Text), ":id" := rowId]
+  r <- query_ conn "SELECT * from test" :: IO [TestField]
+  mapM_ print r
+  execute conn "DELETE FROM test WHERE id = ?" (Only rowId)
+  close conn
+  -}

--- a/src/Nix/StorePath.hs
+++ b/src/Nix/StorePath.hs
@@ -10,6 +10,7 @@ import System.FilePath (takeFileName, takeDirectory, isAbsolute)
 import System.Environment (getEnv)
 import Servant (MimeUnrender(..), OctetStream)
 import Servant.HTML.Lucid (HTML)
+import Data.HashSet (HashSet)
 
 -- | The nix store directory.
 newtype NixStoreDir = NixStoreDir FilePath
@@ -27,7 +28,7 @@ instance Hashable StorePath
 
 -- | A dependency tree, represented as a mapping from a store path to
 -- its set of (immediate, not transitive) dependent paths.
-type PathTree = HashMap StorePath [StorePath]
+type PathTree = HashMap StorePath PathSet
 
 -- | A set of store paths.
 type PathSet = HashSet StorePath
@@ -77,9 +78,13 @@ spToFull (NixStoreDir storeDir) p = storeDir </> spToPath p
 spToFull' :: FullStorePath -> FilePath
 spToFull' = uncurry spToFull
 
+-- | Convert a StorePath to Text.
+spToText :: StorePath -> Text
+spToText (StorePath (StorePrefix hash) name) = hash <> "-" <> name
+
 -- | Convert a StorePath to a FilePath.
 spToPath :: StorePath -> FilePath
-spToPath (StorePath (StorePrefix hash) name) = unpack $ hash <> "-" <> name
+spToPath = unpack . spToText
 
 -- | Find a nix store path by its store prefix. If multiple paths
 -- satisfy the prefix, the first one will be taken.


### PR DESCRIPTION
use sqlite to cache references instead of the filesystem, which gets very slow over time